### PR TITLE
Ignore tracking of any generated files

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -4,3 +4,5 @@
 css/.sass-cache
 node_modules
 npm-debug.log
+css/
+main.min.js


### PR DESCRIPTION
We're tracking generated files that should be ignored, as these can be
automatically generated at each build, instead of tracking the noise
within commits, making merges and diffs more complex.

Noticed from the commit added in https://github.com/HackSocNotts/wit/commit/35b792767fa5915f2f569ebaa3c1c34d90275160. In order to merge this cleanly, a rebase will be needed on `staging` in order to remove those files. 
