### PR TITLE
Update install instructions

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,9 +8,12 @@ Hosted at http://www.inspirewit.com/
 
 ## How to Build
 
-- Uses Grunt
-- Run `sudo npm install` in main directory
+- Install a web server with PHP support
+- Clone the repository into your web server root directory, i.e. `/var/www/wit`
+- Install `grunt` globally, by running `sudo npm -g install grunt-cli`
+- Install all dependencies by running `npm install`
 - Run `grunt watch` to watch folders so that SCSS compiles to CSS & JS combines, or just run `grunt` to build all.
+- Browse to the web server, i.e. `http://localhost:80/wit/index.html`
 
 
 ## Deploying changes


### PR DESCRIPTION
- we shouldn't be recommending a `sudo npm install` for project
  dependencies; it's a good way to get things breaking due to
  permissions
- we need to have `grunt-cli` globally installed to run the Gruntfile
- we haven't mentioned the requirement for having a web server, because
  of the PHP dependency