### PR TITLE
Add PHP-FPM and Nginx configs

### DIFF
--- a/config/etc/nginx/include.d/inspirewit.com-common
+++ b/config/etc/nginx/include.d/inspirewit.com-common
@@ -1,0 +1,14 @@
+index index.php index.html;
+
+location ~ /\.ht {
+	deny all;
+}
+
+location ~ \.php$ {
+	try_files $uri =404;
+	fastcgi_pass unix:/var/run/php5-fpm-inspirewit_com.sock;
+	fastcgi_index index.php;
+	include fastcgi_params;
+	fastcgi_param  SCRIPT_FILENAME  $document_root$fastcgi_script_name;
+}
+

--- a/config/etc/nginx/sites-available/inspirewit.com
+++ b/config/etc/nginx/sites-available/inspirewit.com
@@ -1,0 +1,49 @@
+server {
+	listen 80;
+	server_name inspirewit.com www.inspirewit.com;
+	return 301 $scheme://2017.inspirewit.com$request_uri;
+}
+
+server {
+	listen 80;
+
+	root /srv/www/inspirewit.com/inspirewit.com/production/current;
+	index index.php index.html;
+
+	server_name 2017.inspirewit.com current.inspirewit.com;
+
+	include /etc/nginx/include.d/inspirewit.com-common;
+}
+
+server {
+	listen 80;
+
+	root /srv/www/inspirewit.com/inspirewit.com/staging/current;
+	index index.php index.html;
+
+	server_name staging.inspirewit.com;
+
+	include /etc/nginx/include.d/inspirewit.com-common;
+}
+
+server {
+	listen 80;
+
+	root /srv/www/inspirewit.com/inspirewit.com/2016;
+	index index.php index.html;
+
+	server_name 2016.inspirewit.com;
+
+	include /etc/nginx/include.d/inspirewit.com-common;
+}
+
+server {
+	listen 80;
+
+	root /srv/www/inspirewit.com/inspirewit.com/2014;
+	index index.php index.html;
+
+	server_name 2014.inspirewit.com 2015.inspirewit.com;
+
+	include /etc/nginx/include.d/inspirewit.com-common;
+}

--- a/config/etc/php5/fpm/pool.d/inspirewit_com.conf
+++ b/config/etc/php5/fpm/pool.d/inspirewit_com.conf
@@ -1,0 +1,14 @@
+[inspirewit_com]
+user = inspirewit_com
+group = inspirewit_com
+listen = /var/run/php5-fpm-inspirewit_com.sock
+listen.owner = www-data
+listen.group = www-data
+php_admin_value[disable_functions] = exec,passthru,shell_exec,system
+php_admin_flag[allow_url_fopen] = off
+pm = dynamic
+pm.max_children = 5
+pm.start_servers = 2
+pm.min_spare_servers = 1
+pm.max_spare_servers = 3
+chdir = /


### PR DESCRIPTION
Instead of having our configuration files completely out-of-tree, as it
is now, it would probably be a good idea being able to have the
configuration files stored alongside the code that it refers to.

Closes #25. Part of #35.